### PR TITLE
Fixing missing genre in Novellfull 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## ABOUT
 
-_Download translated web/light novels from a list of pirate sites._  
+_Download and update translated web/light novels from a list of sites._  
 List of supported sites:
 
 -	[NovelFull](https://novelfull.com/)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ List of supported sites:
 -   [~~NovelPlanet~~](https://novelplanet.com/) _offline_
 
 Author: _dr-nyt_  
-Version: _2.0.0_
+Version: _2.0.5_
 
 ## FEATURES
 

--- a/src/app/services/novel-factory.service.ts
+++ b/src/app/services/novel-factory.service.ts
@@ -47,6 +47,7 @@ export class NovelFactoryService {
 		{
 			novel.author = 'Unkown'
 		}
+		console.log("Creating Epub with metadata");
 		console.log(novel)
 		// Set some meta data for the epub file
 		const metadata = {
@@ -68,7 +69,6 @@ export class NovelFactoryService {
 		const epub = epubGen.document(metadata);
 		for (const chapter of chapters)
 			epub.addSection(chapter.title, chapter.data);
-		console.log("starting writing")
 		setTimeout(async () => {
 			await epub.writeEPUB(novelFolder, novelFile);
 

--- a/src/app/services/novel-factory.service.ts
+++ b/src/app/services/novel-factory.service.ts
@@ -42,13 +42,13 @@ export class NovelFactoryService {
 		// If the novel doesnt have a genre we default "Unknown"; empty or null will crash the epub creation
 		if (novel.genre == null || novel.genre == "")
 		{
-			novel.genre = 'Unkown'
+			novel.genre = 'unknown'
 		}
 
 		// If the novel doesnt have a author we default "Unknown"; empty or null will crash the epub creation
 		if (novel.author == null || novel.author == "")
 		{
-			novel.author = 'Unkown'
+			novel.author = 'unknown'
 		}
 		console.log("Creating Epub with metadata");
 		console.log(novel)

--- a/src/app/services/novel-factory.service.ts
+++ b/src/app/services/novel-factory.service.ts
@@ -38,6 +38,16 @@ export class NovelFactoryService {
 		// Download the cover and get its path
 		const coverPath = await this.downloadCover(novel.cover, novelFolder);
 
+		if (novel.genre == null || novel.genre == "")
+		{
+			novel.genre = 'Unkown'
+		}
+
+		if (novel.author == null || novel.author == "")
+		{
+			novel.author = 'Unkown'
+		}
+		console.log(novel)
 		// Set some meta data for the epub file
 		const metadata = {
 			id: "0000-0000-0001",
@@ -58,7 +68,7 @@ export class NovelFactoryService {
 		const epub = epubGen.document(metadata);
 		for (const chapter of chapters)
 			epub.addSection(chapter.title, chapter.data);
-
+		console.log("starting writing")
 		setTimeout(async () => {
 			await epub.writeEPUB(novelFolder, novelFile);
 

--- a/src/app/services/novel-factory.service.ts
+++ b/src/app/services/novel-factory.service.ts
@@ -38,11 +38,14 @@ export class NovelFactoryService {
 		// Download the cover and get its path
 		const coverPath = await this.downloadCover(novel.cover, novelFolder);
 
+
+		// If the novel doesnt have a genre we default "Unknown"; empty or null will crash the epub creation
 		if (novel.genre == null || novel.genre == "")
 		{
 			novel.genre = 'Unkown'
 		}
 
+		// If the novel doesnt have a author we default "Unknown"; empty or null will crash the epub creation
 		if (novel.author == null || novel.author == "")
 		{
 			novel.author = 'Unkown'

--- a/src/app/services/sources/novelfull.service.ts
+++ b/src/app/services/sources/novelfull.service.ts
@@ -98,6 +98,12 @@ export class NovelfullService extends sourceService {
 			}
 			novel.genre = genre.slice(0, -2);
 
+			// defaulting if none is found.
+			if (novel.genre == null || novel.genre == "")
+			{
+				novel.genre = "unknown"
+			}
+
 			// FIXME: Summary
 			const summaryList = html
 				.getElementsByClassName("desc-text")[0]
@@ -111,6 +117,12 @@ export class NovelfullService extends sourceService {
 			} catch (error) {
 				novel.summary = "N/A";
 				console.log(error);
+			}
+
+			// defaulting if none is found.
+			if (novel.summary == null || novel.summary == "")
+			{
+				novel.summary = "unknown"
 			}
 
 			//////////////////////// YOUR CODE ENDS HERE /////////////////////////////////


### PR DESCRIPTION
i changed the writer of the epub, so that it would check if the author or genre is missing from the novel metadata. if so i default some value.

the epub writer seems to require that we supply those 2 fields, otherwise it will fail silently and keep stuck at 99% when downloading.